### PR TITLE
Fixing pad byte in Dot11EltCountry

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -906,7 +906,7 @@ class Dot11EltCountry(Dot11Elt):
         ),
         ConditionalField(
             ByteField("pad", 0),
-            lambda pkt: (pkt.len + 1) % 2
+            lambda pkt: (len(pkt.descriptors) * 3) + 3 != pkt.len
         )
     ]
 


### PR DESCRIPTION
More info : #2248
based on the standard, the length of the field should be the even number, so a pad byte should be included if the length of element is not an even number, but it seems that `pkt.len` is referred from header, `pkt.len` includes the pad byte already.
This change calculates the length of body and compare it to the `pkt.len` so that the pad will be correctly applied.
fixes #2248
